### PR TITLE
Linker flag build fix for win32 and Linux

### DIFF
--- a/src/sdl/Makefile.cfg
+++ b/src/sdl/Makefile.cfg
@@ -83,11 +83,6 @@ else
 	SDL_LDFLAGS+=-lSDL2_mixer
 endif
 
-ifndef NOOPENMPT
-OPTS+=-DHAVE_OPENMPT
-SDL_LDFLAGS+=-llibopenmpt
-endif
-
 ifdef SDL_TTF
 	OPTS+=-DHAVE_TTF
 	SDL_LDFLAGS+=-lSDL2_ttf -lfreetype -lz

--- a/src/win32/Makefile.cfg
+++ b/src/win32/Makefile.cfg
@@ -22,7 +22,7 @@ else
 	SDL_LDFLAGS?=-L../libs/SDL2/i686-w64-mingw32/lib -L../libs/SDL2_mixer/i686-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows
 	HAVE_OPENMPT=1
 	LIBOPENMPT_CFLAGS?=-I../libs/libopenmpt/inc
-	LIBOPENMPT_LDFLAGS?=-L../libs/libopenmpt/lib/x86
+	LIBOPENMPT_LDFLAGS?=-L../libs/libopenmpt/lib/x86 -llibopenmpt
 endif
 
 ifndef NOASM


### PR DESCRIPTION
The linker flag in `src/sdl/Makefile.cfg` was overriding the supplied linker flags on Linux, so I fixed that by removing the entry in that file.

On Debian, the flag is `-lopenmpt`, whereas on Windows, it's still `-llibopenmpt`. Don't know why they're different, but I also added an appropriate entry in `src/win32/Makefile.cfg` to use the latter flag.

All in all, this builds great on both platforms. Too bad the buildbots all fail because they can't find the `libopenmpt-dev` package :(